### PR TITLE
fixes issue with picker jumping months

### DIFF
--- a/utils/DateUtils.js
+++ b/utils/DateUtils.js
@@ -44,8 +44,8 @@ var DateUtils = {
     createNewDayMonth: function(date, month, time) {
         var newDate = new Date();
         newDate.setTime(time);
-        newDate.setMonth(month);
         newDate.setDate(date);
+        newDate.setMonth(month);
         return newDate;
     }
 }


### PR DESCRIPTION
When the user has a day selected that is past
the number of days in the next month, the
picker would jump 2 months when the user
advances rather than 1.

This is because the month was set, then the
day was set, if the day number is `31` and
there are `28` days in a month, then js's
date class sets the month value forward.

Moving the day value being set before the
month prevents this behaivor. If the month
were to have been put forward, the setMonth
then resets it to the proper month.
