### PR TITLE
version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datepicker-component",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "A standalone ReactJS datepicker component, no jquery etc..",
   "author" : "Mandarin Drummond",
   "contributors" : ["Michal Biros <birosh@gmail.com>"],


### PR DESCRIPTION
npm recommends now that packages start at at least 1.0.0,
especially if they are used as plugins and could be
listed as `peerDependencies` in other packages
