### PR TITLE
react moved to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "type": "git",
     "url": "https://github.com/MandarinConLaBarba/react-datepicker.git"
   },
-  "dependencies": {
-    "react": "^0.10.0",
-    "gulp": "^3.6.0"
+  "peerDependencies": {
+    "react": ">=0.10.0"
   },
   "devDependencies": {
+    "gulp": "^3.6.0",
     "vinyl-source-stream": "^0.1.1",
     "gulp-mocha": "^0.5.2",
     "gulp": "^3.8.7",


### PR DESCRIPTION
`react` should not be in list of dependencies because `browserify` will build bundle with two reacts (one is from project and one is from datepicker). `react-datepicker` should use existing `react`
