### PR TITLE
createNewDayMonth is called with the current time when building the list...

### DIFF
--- a/DayPicker.jsx
+++ b/DayPicker.jsx
@@ -20,7 +20,7 @@ var DayPicker = React.createClass(/** @lends {React.ReactComponent.prototype} */
             daysArray = DateUtils.getArrayByBoundary(beforeDaysCount-offset+1, beforeDaysCount);
 
         var previousMonthDays = daysArray.map(function(day){
-            var thisDate = DateUtils.createNewDayMonth(day, date.getMonth()-1, date.getTime());
+            var thisDate = DateUtils.createNewDayMonth(day, date.getMonth()-1, 0);
             return <Day key={'day-prev-mo-' + day} date={thisDate} week={1} changeDate={this.selectDay} />
         }.bind(this));
 


### PR DESCRIPTION
... of dates in the last days of last month, prior to the first day of this month.

This causes it to return a bad date and so when looking at Feb 2015 (for example) it will display 26, 27, 28, 1, 2, 3 as the last 6 days of Jan 2015.
My fix is to pass 0 as the current time to createNewDayMonth.